### PR TITLE
Configure PHP, Pla and add a Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Cywin environment setup
+A shell script that installs and configures your cygwin environment.
+
+## How to use
+1. [Install Cygwin](https://cygwin.com/install.html)
+1. Make sure you've checked/installed WGET when installing Cygwin
+1. Clone this repository
+1. Execute the `setup-env.sh` with cygwin
+
+## What does it install
+Below is a list of packages/components/settings cygwin installs (if not available already).
+
+- apt-cyg
+- keychain
+- git
+- vim
+- zsh
+- curl
+- php
+- nodejs
+- oh-my-zsh
+- pip
+- pla
+
+## What does it configure
+- Replaces your .minttyrc with a clear theme
+- Configures oh-my-zsh bira theme
+- Optionally generates a SSH keypair

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A shell script that installs and configures your cygwin environment.
 
 ## How to use
-1. [Install Cygwin](https://cygwin.com/install.html)
+1. [Install Cygwin](https://cygwin.com/install.html), use 64 bits for optimal support
 1. Make sure you've checked/installed WGET when installing Cygwin
 1. Clone this repository
 1. Execute the `setup-env.sh` with cygwin

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A shell script that installs and configures your cygwin environment.
 1. Make sure you've checked/installed WGET when installing Cygwin
 1. Clone this repository
 1. Execute the `setup-env.sh` with cygwin
+1. After cygwin boots oh-my-zsh. please `exit` it to allow the script to configure oh-my-zsh.
 
 ## What does it install
 Below is a list of packages/components/settings cygwin installs (if not available already).

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -31,13 +31,41 @@ fi
 echo
 
 # Install some base packages
-echo "Step 3, installing some base packages..."
+echo "Step 3, installing some base packages available in apt-cyg..."
 apt-cyg install git vim zsh curl wget > /dev/null
 echo 'Done.'
 echo
 
+# Installing pip
+echo 'Step 4, installing pip & pla...'
+apt-cyg install python > /dev/null
+if [ -f /usr/bin/pip ]; then
+    echo 'Pip already installed.'
+else
+  wget -qO /tmp/pip_installer.py https://bootstrap.pypa.io/get-pip.py
+  python /tmp/pip_installer.py
+fi
+if [ -f /usr/bin/pla ]; then
+    echo 'Pla already installed.'
+else
+  pip install pla
+fi
+echo
+
+# Installing Composer
+echo 'Step 5, installing Composer and requirements...'
+apt-cyg install php php-json php-phar php-curl php-iconv php-mbstring > /dev/null
+if [ -f /usr/local/bin/composer ]; then
+    echo 'Already installed.'
+else
+  wget https://raw.githubusercontent.com/composer/getcomposer.org/1b137f8bf6db3e79a38a5bc45324414a6b1f9df2/web/installer -O - -q | php --
+  mv composer.phar /usr/local/bin/composer
+  chmod +x /usr/local/bin/composer
+fi
+echo
+
 # Installing Oh-My-ZSH
-echo 'Step 4, installing Oh-My-zsh...'
+echo 'Step 6, installing Oh-My-zsh...'
 if [ -d ~/.oh-my-zsh ]; then
     echo 'Already installed.'
 else
@@ -46,19 +74,19 @@ fi
 echo
 
 # Grabbing a sane Mintty configuration
-echo Step 5, configuring Mintty...
+echo Step 7, configuring Mintty...
 wget -qO ~/.minttyrc https://raw.githubusercontent.com/eXistenZNL/cygwin-setup/master/.minttyrc
 echo 'Done.'
 echo
 
 # Configure Oh-My-ZSH
-echo 'Step 6, configuring Oh-My-zsh...'
+echo 'Step 8, configuring Oh-My-zsh...'
 sed -i 's/ZSH_THEME=.*/ZSH_THEME=bira/' ~/.zshrc
 echo "Done."
 echo
 
 # Creating pubkey
-echo 'Step 7, optionally creating a pubkey...'
+echo 'Step 9, optionally creating a pubkey...'
 if [ -f ~/.ssh/$USERNAME ]; then
     echo "A pubkey with the filename /.ssh/$USERNAME already exists, skipping creation..."
 else

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -38,6 +38,7 @@ echo
 
 # Installing pip
 echo 'Step 4, installing pip & pla...'
+
 apt-cyg install python > /dev/null
 if [ -f /usr/bin/pip ]; then
     echo 'Pip already installed.'
@@ -45,10 +46,16 @@ else
   wget -qO /tmp/pip_installer.py https://bootstrap.pypa.io/get-pip.py
   python /tmp/pip_installer.py
 fi
+echo
+
 if [ -f /usr/bin/pla ]; then
     echo 'Pla already installed.'
 else
-  pip install pla
+  if uname -a | grep "i686"; then
+      echo 'Skiping pla installation due to unsuported 32-bits cygwin'
+  else
+      pip install pla
+  fi
 fi
 echo
 


### PR DESCRIPTION
### What has been done
- Added a readme
- Installed PHP
- Installed Composer
- Installed Pip
- Installed Pla (if you're on 64 bits)

### How to test
- Clone the PR
- Run the install script
- Notice how you now have `composer`, `php`, `pla`, and  `pip` as additional binaries

### Notes
- Did not install node.js since this is no longer supported on Cygwin. Users should install node normally and make it available in their $path.
