### PR TITLE
Add the cygwin symlink step to the installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A shell script that installs and configures your cygwin environment.
 1. Clone this repository
 1. Execute the `setup-env.sh` with cygwin
 1. After cygwin boots oh-my-zsh. please `exit` it to allow the script to configure oh-my-zsh.
+1. Please modify the Cygwin Terminal symlink you use to start Cygwin (e.g. in the start menu) so it reads like this: `...\mintty.exe -i /Cygwin-Terminal.ico -d /bin/zsh --login`
 
 ## What does it install
 Below is a list of packages/components/settings cygwin installs (if not available already).


### PR DESCRIPTION
After installing the environment, your terminal requests to overwrite the symlink. Because of all the other output during the installation this request can be "missed" easily. This PR adds the last step to the setup manual, enforcing you to fix it.